### PR TITLE
tag events on creation

### DIFF
--- a/lib/wavefront-cli/base.rb
+++ b/lib/wavefront-cli/base.rb
@@ -67,8 +67,8 @@ module WavefrontCli
       send(:extra_validation) if respond_to?(:extra_validation)
     end
 
-    def validate_tags
-      Array(options[:'<tag>']).each do |t|
+    def validate_tags(key = :'<tag>')
+      Array(options[key]).each do |t|
         begin
           send(:wf_tag?, t)
         rescue Wavefront::Exception::InvalidTag

--- a/lib/wavefront-cli/commands/event.rb
+++ b/lib/wavefront-cli/commands/event.rb
@@ -6,18 +6,19 @@ class WavefrontCommandEvent < WavefrontCommandBase
   def description
     'open, close, view, and manage events'
   end
+
   def _commands
     ["list #{CMN} [-l] [-f format] [-s start] [-e end] [-L limit] " \
       '[-o cursor]',
      "describe #{CMN} [-f format] <id>",
      "create #{CMN} [-d description] [-s time] [-i | -e time] " \
-     '[-S severity] [-T type] [-H host...] [-N] <event>',
+     '[-S severity] [-T type] [-H host...] [-g tag...] [-N] <event>',
      "close #{CMN} [<id>]",
      "delete #{CMN} <id>",
      "update #{CMN} <key=value> <id>",
      "search #{CMN} [-f format] [-o offset] [-L limit] [-l] <condition>...",
      "wrap #{CMN} [-C command] [-d description] [-S severity] [-T type] " \
-     '[-H host...] <event>',
+     '[-H host...] [-g tag...] <event>',
      tag_commands,
      'show [-D]']
   end
@@ -36,6 +37,7 @@ class WavefrontCommandEvent < WavefrontCommandBase
      '-H, --host=STRING         source to which event applies',
      '-N, --nostate             do not create a local file recording ' \
      'the event',
+     '-g, --evtag=TAG           event tag',
      '-C, --command=COMMAND     command to run',
      '-f, --format=STRING       output format']
   end

--- a/lib/wavefront-cli/event.rb
+++ b/lib/wavefront-cli/event.rb
@@ -104,6 +104,7 @@ module WavefrontCli
       body[:annotations][:severity] = opts[:severity] if opts[:severity]
       body[:annotations][:type] = opts[:type] if opts[:type]
       body[:hosts] = opts[:host] if opts[:host]
+      body[:tags] = opts[:evtag] if opts[:evtag]
 
       if opts[:instant]
         body[:endTime] = t_start + 1
@@ -179,6 +180,7 @@ module WavefrontCli
     def validate_input
       validate_id if options[:'<id>'] && !options[:close]
       validate_tags if options[:'<tag>']
+      validate_tags(:evtag) if options[:evtag]
       send(:extra_validation) if respond_to?(:extra_validation)
     end
 

--- a/lib/wavefront-cli/version.rb
+++ b/lib/wavefront-cli/version.rb
@@ -1,1 +1,1 @@
-WF_CLI_VERSION = '2.1.4'.freeze
+WF_CLI_VERSION = '2.1.5'.freeze


### PR DESCRIPTION
Use `-g` to add event tags. `-t` and `-T` have gone. Docopt forces us to use something other than `--tag` for the long option.