### PR TITLE
Drop support for Ruby 2.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 ---
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   NewCops: enable
 
 Metrics/ClassLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,48 +2,17 @@
 
 AllCops:
   TargetRubyVersion: 2.4
+  NewCops: enable
 
 Metrics/ClassLength:
   Max: 400
 
 Style/IfUnlessModifier:
   Enabled: false # because it wants to make lines >80 chars
-Style/HashEachMethods:
-    Enabled: true
-Style/HashTransformKeys:
-    Enabled: true
-Style/HashTransformValues:
-    Enabled: true
-
-# New compatabilities
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-Lint/RaiseException:
-  Enabled: true
-Lint/StructNewOverride:
-  Enabled: true
-Style/ExponentialNotation:
-  Enabled: true
-Style/SlicingWithRange:
-  Enabled: true
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-Style/RedundantRegexpEscape:
-  Enabled: true
-Style/AccessorGrouping:
-  Enabled: true
-Style/BisectedAttrAccessor:
-  Enabled: true
-Style/RedundantAssignment:
-  Enabled: true
-Style/RedundantFetchBlock:
-  Enabled: true
+Style/StringConcatenation:
+  Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false
 
 # Is nothing sacred?
 Layout/LineLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
-  - 2.7.0
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 before_install: gem install bundler --no-document
 deploy:
   provider: rubygems
@@ -14,7 +14,7 @@ deploy:
   on:
     tags: true
     repo: snltd/wavefront-cli
-    ruby: 2.6.5
+    ruby: 2.6.6
 notifications:
   email: false
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.4.10
   - 2.5.8
   - 2.6.6
   - 2.7.1

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.0.0 (2020-09-20
+* Drop Ruby 2.4.0 support. (Breaking change.)
+
 ## 7.2.0 (2020-08-12)
 * Add `cloudintegration awsid generate` command.
 * Add `cloudintegration awsid delete <external_id>` command.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ gem install wavefront-cli
 
 It is built on [our Wavefront Ruby
 SDK](https://github.com/snltd/wavefront-sdk) and requires Ruby >=
-2.4. It has no "native extension" dependencies.
+2.5. It has no "native extension" dependencies.
 
 For a far more comprehensive overview/tutorial, please read [this
 article](https://sysdef.xyz/article/wavefront-cli).

--- a/lib/wavefront-cli/base.rb
+++ b/lib/wavefront-cli/base.rb
@@ -371,9 +371,10 @@ module WavefrontCli
     def do_dump
       cannot_noop!
 
-      if options[:format] == 'yaml'
+      case options[:format]
+      when 'yaml'
         ok_exit dump_yaml
-      elsif options[:format] == 'json'
+      when 'json'
         ok_exit dump_json
       else
         abort format("Dump format must be 'json' or 'yaml'. " \
@@ -539,7 +540,8 @@ module WavefrontCli
     #
     # rubocop:disable Metrics/MethodLength
     def extract_values(obj, key, aggr = [])
-      if obj.is_a?(Hash)
+      case obj.class
+      when Hash
         obj.each_pair do |k, v|
           if k == key && !v.to_s.empty?
             aggr.<< v
@@ -547,7 +549,7 @@ module WavefrontCli
             extract_values(v, key, aggr)
           end
         end
-      elsif obj.is_a?(Array)
+      when Array
         obj.each { |e| extract_values(e, key, aggr) }
       end
 

--- a/lib/wavefront-cli/base.rb
+++ b/lib/wavefront-cli/base.rb
@@ -102,12 +102,10 @@ module WavefrontCli
 
     def validate_tags(key = :'<tag>')
       Array(options[key]).each do |t|
-        begin
-          send(:wf_tag?, t)
-        rescue Wavefront::Exception::InvalidTag
-          raise(WavefrontCli::Exception::InvalidInput,
-                "'#{t}' is not a valid tag.")
-        end
+        send(:wf_tag?, t)
+      rescue Wavefront::Exception::InvalidTag
+        raise(WavefrontCli::Exception::InvalidInput,
+              "'#{t}' is not a valid tag.")
       end
     end
 

--- a/lib/wavefront-cli/commands/.rubocop.yml
+++ b/lib/wavefront-cli/commands/.rubocop.yml
@@ -1,47 +1,19 @@
 ---
+AllCops:
+  NewCops: enable
 
 # There are long things in here, but they're fine
 #
 Metrics/MethodLength:
   Max: 25
 
-Style/HashEachMethods:
-    Enabled: true
-Style/HashTransformKeys:
-    Enabled: true
-Style/HashTransformValues:
-    Enabled: true
-
-# new compatabilities
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-Lint/RaiseException:
-  Enabled: true
-Lint/StructNewOverride:
-  Enabled: true
-Style/ExponentialNotation:
-  Enabled: true
-Style/SlicingWithRange:
-  Enabled: true
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-Style/RedundantRegexpEscape:
-  Enabled: true
-Style/AccessorGrouping:
-  Enabled: true
-Style/BisectedAttrAccessor:
-  Enabled: true
-Style/RedundantAssignment:
-  Enabled: true
-Style/RedundantFetchBlock:
-  Enabled: true
-
 # Is nothing sacred?
 Layout/LineLength:
   Max: 80
+
+Style/IfUnlessModifier:
+  Enabled: false # because it wants to make lines >80 chars
+Style/StringConcatenation:
+  Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false

--- a/lib/wavefront-cli/config.rb
+++ b/lib/wavefront-cli/config.rb
@@ -36,11 +36,13 @@ module WavefrontCli
 
     RX = /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/.freeze
 
+    # rubocop:disable Lint/MissingSuper
     def initialize(options)
       @options = options
       @config_file = _config_file
       @profile = options[:'<profile>'] || 'default'
     end
+    # rubocop:enable Lint/MissingSuper
 
     def do_location
       puts config_file
@@ -144,7 +146,7 @@ module WavefrontCli
     # catch a ctrl-d
     #
     def read_input
-      STDIN.gets.strip
+      $stdin.gets.strip
     rescue NoMethodError
       abort "\nInput aborted at user request."
     end

--- a/lib/wavefront-cli/controller.rb
+++ b/lib/wavefront-cli/controller.rb
@@ -177,8 +177,6 @@ class WavefrontCliController
   # return [Hash] h with modified keys
   #
   def sanitize_keys(options)
-    options.each_with_object({}) do |(k, v), r|
-      r[k.to_s.delete('-').to_sym] = v
-    end
+    options.transform_keys { |k| k.to_s.delete('-').to_sym }
   end
 end

--- a/lib/wavefront-cli/display/printer/long.rb
+++ b/lib/wavefront-cli/display/printer/long.rb
@@ -75,16 +75,17 @@ module WavefrontDisplayPrinter
     #
     # Make an array of hashes: { key, value, depth }
     #
+    # rubocop:disable Style/CaseLikeIf
     def make_list(data, aggr = [], depth = 0, last_key = nil)
-      case data.class
-      when Hash
+      if data.is_a?(Hash)
         append_hash(data, aggr, depth)
-      when Array
+      elsif data.is_a?(Array)
         append_array(data, aggr, depth, last_key)
       else
         aggr.<< ['', preened_value(data), depth]
       end
     end
+    # rubocop:enable Style/CaseLikeIf
 
     def smart_value(val)
       val.to_s.empty? && opts[:none] ? '<none>' : preened_value(val)
@@ -151,13 +152,12 @@ module WavefrontDisplayPrinter
     # @param depth [Integer]
     # @return [Array[Array]]
     #
-    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Style/CaseLikeIf
     def append_hash(data, aggr, depth)
       data.each_pair do |k, v|
-        case v.class
-        when Hash
+        if v.is_a?(Hash)
           aggr = append_hash_values(k, v, aggr, depth)
-        when Array
+        elsif v.is_a?(Array)
           aggr = append_array_values(k, v, aggr, depth)
         else
           aggr.<< [k, smart_value(v), depth]
@@ -166,7 +166,7 @@ module WavefrontDisplayPrinter
 
       aggr
     end
-    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Style/CaseLikeIf
 
     # Part of the #make_list recursion. Deals with arrays.
     #

--- a/lib/wavefront-cli/display/printer/long.rb
+++ b/lib/wavefront-cli/display/printer/long.rb
@@ -76,9 +76,10 @@ module WavefrontDisplayPrinter
     # Make an array of hashes: { key, value, depth }
     #
     def make_list(data, aggr = [], depth = 0, last_key = nil)
-      if data.is_a?(Hash)
+      case data.class
+      when Hash
         append_hash(data, aggr, depth)
-      elsif data.is_a?(Array)
+      when Array
         append_array(data, aggr, depth, last_key)
       else
         aggr.<< ['', preened_value(data), depth]
@@ -150,11 +151,13 @@ module WavefrontDisplayPrinter
     # @param depth [Integer]
     # @return [Array[Array]]
     #
+    # rubocop:disable Metrics/MethodLength
     def append_hash(data, aggr, depth)
       data.each_pair do |k, v|
-        if v.is_a?(Hash)
+        case v.class
+        when Hash
           aggr = append_hash_values(k, v, aggr, depth)
-        elsif v.is_a?(Array)
+        when Array
           aggr = append_array_values(k, v, aggr, depth)
         else
           aggr.<< [k, smart_value(v), depth]
@@ -163,6 +166,7 @@ module WavefrontDisplayPrinter
 
       aggr
     end
+    # rubocop:enable Metrics/MethodLength
 
     # Part of the #make_list recursion. Deals with arrays.
     #

--- a/lib/wavefront-cli/event.rb
+++ b/lib/wavefront-cli/event.rb
@@ -97,6 +97,7 @@ module WavefrontCli
     # return [Hash] body for #create() method
     #
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def create_body(opts, t_start)
       { name: opts[:'<event>'],
         startTime: t_start,
@@ -111,6 +112,7 @@ module WavefrontCli
           end
         end
     end
+    # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
     def annotations(opts)

--- a/lib/wavefront-cli/exception_handler.rb
+++ b/lib/wavefront-cli/exception_handler.rb
@@ -8,7 +8,6 @@ module WavefrontCli
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     def exception_handler(exception)
       case exception
       when WavefrontCli::Exception::UnhandledCommand
@@ -83,7 +82,6 @@ module WavefrontCli
     end
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/PerceivedComplexity
     # rubocop:enable Metrics/CyclomaticComplexity
   end
 end

--- a/lib/wavefront-cli/externallink.rb
+++ b/lib/wavefront-cli/externallink.rb
@@ -38,12 +38,10 @@ module WavefrontCli
 
     def point_filter_regexes
       ret = options[:pointregex].each_with_object({}) do |r, a|
-        begin
-          k, v = r.split('=', 2)
-          a[k.to_sym] = v
-        rescue StandardError
-          puts "cannot parse point regex '#{r}'. Skipping."
-        end
+        k, v = r.split('=', 2)
+        a[k.to_sym] = v
+      rescue StandardError
+        puts "cannot parse point regex '#{r}'. Skipping."
       end
 
       ret.empty? ? nil : ret

--- a/lib/wavefront-cli/helpers/load_file.rb
+++ b/lib/wavefront-cli/helpers/load_file.rb
@@ -57,7 +57,7 @@ module WavefrontCli
       #   does not parse
       #
       def load_from_stdin
-        raw = STDIN.read
+        raw = $stdin.read
 
         if raw.start_with?('---')
           read_yaml(raw)

--- a/lib/wavefront-cli/opt_handler.rb
+++ b/lib/wavefront-cli/opt_handler.rb
@@ -69,7 +69,7 @@ module WavefrontCli
     #
     def load_profile(cred_opts)
       creds = Wavefront::Credentials.new(cred_opts).config
-      Hash[creds.map { |k, v| [k.to_sym, v] }]
+      creds.transform_keys(&:to_sym)
     end
   end
 end

--- a/lib/wavefront-cli/opt_handler.rb
+++ b/lib/wavefront-cli/opt_handler.rb
@@ -2,7 +2,7 @@
 
 require 'pathname'
 require 'wavefront-sdk/credentials'
-require_relative 'constants.rb'
+require_relative 'constants'
 
 module WavefrontCli
   #

--- a/lib/wavefront-cli/write.rb
+++ b/lib/wavefront-cli/write.rb
@@ -167,12 +167,10 @@ module WavefrontCli
     #
     def process_input_file(data)
       data.each_with_object([]) do |l, a|
-        begin
-          a.<< process_line(l)
-        rescue WavefrontCli::Exception::UnparseableInput => e
-          puts "Bad input. #{e.message}."
-          next
-        end
+        a.<< process_line(l)
+      rescue WavefrontCli::Exception::UnparseableInput => e
+        puts "Bad input. #{e.message}."
+        next
       end
     end
 

--- a/lib/wavefront-cli/write.rb
+++ b/lib/wavefront-cli/write.rb
@@ -193,7 +193,7 @@ module WavefrontCli
     #
     def read_stdin
       open_connection
-      STDIN.each_line { |l| call_write(process_line(l.strip), false) }
+      $stdin.each_line { |l| call_write(process_line(l.strip), false) }
       close_connection
     rescue SystemExit, Interrupt
       puts 'ctrl-c. Exiting.'

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -1,4 +1,7 @@
 ---
+AllCops:
+  NewCops: enable
+
 Metrics/MethodLength:
   Max: 30
 
@@ -8,43 +11,13 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Max: 300
 
-Style/HashEachMethods:
-    Enabled: true
-Style/HashTransformKeys:
-    Enabled: true
-Style/HashTransformValues:
-    Enabled: true
-
-# new compatabilities
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-Lint/RaiseException:
-  Enabled: true
-Lint/StructNewOverride:
-  Enabled: true
-Style/ExponentialNotation:
-  Enabled: true
-Style/SlicingWithRange:
-  Enabled: true
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-Style/RedundantRegexpEscape:
-  Enabled: true
-Style/AccessorGrouping:
-  Enabled: true
-Style/BisectedAttrAccessor:
-  Enabled: true
-Style/RedundantAssignment:
-  Enabled: true
-Style/RedundantFetchBlock:
-  Enabled: true
-
 # Is nothing sacred?
 Layout/LineLength:
   Max: 80
+
+Style/IfUnlessModifier:
+  Enabled: false # because it wants to make lines >80 chars
+Style/StringConcatenation:
+  Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false

--- a/spec/support/minitest_assertions.rb
+++ b/spec/support/minitest_assertions.rb
@@ -105,11 +105,9 @@ module Minitest
                    "performed as no-ops.\n", err)
     end
 
-    def assert_repeated_output(msg)
+    def assert_repeated_output(msg, &block)
       begin
-        out, err = capture_io do
-          yield
-        end
+        out, err = capture_io(&block)
       rescue SystemExit => e
         puts e.backtrace
         p e

--- a/spec/wavefront-cli/config_spec.rb
+++ b/spec/wavefront-cli/config_spec.rb
@@ -48,7 +48,7 @@ class WavefrontCliConfigTest < MiniTest::Test
 
   def test_read_input
     ["value  \n", " value\n", "    value  \t\n", "value\n"].each do |v|
-      STDIN.stub(:gets, v) { assert_equal('value', wf.read_input) }
+      $stdin.stub(:gets, v) { assert_equal('value', wf.read_input) }
     end
   end
 

--- a/spec/wavefront-cli/controller_spec.rb
+++ b/spec/wavefront-cli/controller_spec.rb
@@ -79,9 +79,11 @@ end
 # so we can get at the methods without triggering one of the things
 # tested above.
 #
+# rubocop:disable Lint/MissingSuper
 class Giblets < WavefrontCliController
   def initialize; end
 end
+# rubocop:enable Lint/MissingSuper
 
 # Here's the subclass
 #

--- a/wavefront-cli.gemspec
+++ b/wavefront-cli.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'minitest', '~> 5.11', '>= 5.11.0'
   gem.add_development_dependency 'rake', '~> 13.0'
-  gem.add_development_dependency 'rubocop', '0.87.1'
+  gem.add_development_dependency 'rubocop', '0.91.0'
   gem.add_development_dependency 'spy', '~> 1.0.0'
   gem.add_development_dependency 'webmock', '~> 3.7'
   gem.add_development_dependency 'yard', '~> 0.9.5'

--- a/wavefront-cli.gemspec
+++ b/wavefront-cli.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'webmock', '~> 3.7'
   gem.add_development_dependency 'yard', '~> 0.9.5'
 
-  gem.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
+  gem.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
 end


### PR DESCRIPTION
Support for Ruby 2.4, which has been EOL for the six months now, is becoming enough of a burden that I am no longer prepared to offer it. 

As of version 8.0.0 `wf` requires Ruby 2.5 or above. Note that even 2.5 is only in security maintenance.