### PR TITLE
catch ctrl-c

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.3.1 (2020-11-17)
+* Catch ctrl-c properly.
+
 ## 8.3.0 (2020-10-31)
 * Add `wf proxy shutdown` command.
 

--- a/lib/wavefront-cli/controller.rb
+++ b/lib/wavefront-cli/controller.rb
@@ -40,6 +40,12 @@ class WavefrontCliController
     cli_class_obj = cli_class(cmd, @opts)
     run_command(cli_class_obj)
   rescue Interrupt
+    handle_interrupt!
+  end
+
+  def handle_interrupt!
+    raise if opts[:debug]
+
     puts "\nCancelled at user's request."
     exit 0
   end

--- a/lib/wavefront-cli/controller.rb
+++ b/lib/wavefront-cli/controller.rb
@@ -39,6 +39,9 @@ class WavefrontCliController
     @opts = parse_opts(opts)
     cli_class_obj = cli_class(cmd, @opts)
     run_command(cli_class_obj)
+  rescue Interrupt
+    puts "\nCancelled at user's request."
+    exit 0
   end
 
   # What you see when you do 'wf --help'

--- a/lib/wavefront-cli/version.rb
+++ b/lib/wavefront-cli/version.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-WF_CLI_VERSION = '8.3.0'
+WF_CLI_VERSION = '8.3.1'


### PR DESCRIPTION
Cancelling operations with ctrl-c produces a stack trace. This is the way you'd normally cancel `spy` operations, so it's not acceptable. You still get the stack trace if you run in debug mode.