### PR TITLE
bring deps up-to-date and lint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     - name: Set env
       run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
 
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby 3.0
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.0
     - run: bundle install
 
     - name: Run tests
@@ -34,4 +34,4 @@ jobs:
         chmod 0600 ${HOME}/.gem/credentials
         gem push pkg/*.gem
       env:
-        GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
+        GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_PUSH_KEY}}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.5.8, 2.6.6, 2.7.2, 3.0.0]
+        ruby-version: [2.7.7, 3.1.3, 3.2.0]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 ---
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   NewCops: enable
 
 require:
@@ -16,7 +16,5 @@ Naming/VariableNumber:
   Enabled: false
 Style/IfUnlessModifier:
   Enabled: false # because it wants to make lines >80 chars
-Style/StringConcatenation:
-  Enabled: false
 Style/OptionalBooleanParameter:
   Enabled: false

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* Drop support for Ruby 2.5. (Breaking change.)
+* Drop support for Ruby 2.6. (Breaking change.)
+* Add `metricspolicy` command.
 * `wf write` has changed.  Tokens and API endpoints are now specified exactly
   like other commands. This means certain options had to change.  A proxy is
   now specified with `-y` instead of `-E`; A timestamp is given with `-s`, not

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ gem install wavefront-cli
 
 It is built on [our Wavefront Ruby
 SDK](https://github.com/snltd/wavefront-sdk) and requires Ruby >=
-2.5. It has no "native extension" dependencies.
+2.7. It has no "native extension" dependencies.
 
 For a far more comprehensive overview/tutorial, please read [this
 article](https://sysdef.xyz/article/wavefront-cli).
@@ -30,6 +30,7 @@ Usage:
   wf --help
 
 Commands:
+  account            view and manage Wavefront accounts
   alert              view and manage alerts
   apitoken           view and your own API tokens
   cloudintegration   view and manage cloud integrations
@@ -45,6 +46,7 @@ Commands:
   notificant         view and manage Wavefront alert targets
   proxy              view and manage proxies
   query              run Wavefront queries
+  role               view and manage roles
   savedsearch        view and manage saved searches
   serviceaccount     view and manage service accounts
   settings           view and manage system preferences

--- a/lib/wavefront-cli/base.rb
+++ b/lib/wavefront-cli/base.rb
@@ -206,7 +206,7 @@ module WavefrontCli
     #
     def method_word_list
       do_methods = methods.select { |m| m.to_s.start_with?('do_') }
-      do_methods.map { |m| m.to_s.split('_')[1..-1] }.sort_by(&:length)
+      do_methods.map { |m| m.to_s.split('_')[1..] }.sort_by(&:length)
     end
 
     # Display a Ruby object as JSON, YAML, or human-readable.  We
@@ -545,7 +545,7 @@ module WavefrontCli
       when Hash
         obj.each_pair do |k, v|
           if k == key && !v.to_s.empty?
-            aggr.<< v
+            aggr << v
           else
             extract_values(v, key, aggr)
           end

--- a/lib/wavefront-cli/commands/base.rb
+++ b/lib/wavefront-cli/commands/base.rb
@@ -80,7 +80,7 @@ class WavefrontCommandBase
   end
 
   def things
-    thing + 's'
+    "#{thing}s"
   end
 
   # @return [String] the name of the SDK class which does the work
@@ -105,10 +105,11 @@ class WavefrontCommandBase
     text_arr = %w[Usage:]
 
     _commands.flatten.each do |cmd|
-      text_arr.<< '  ' + "#{CMD} #{word} #{cmd}\n".cmd_fold(term_width)
+      folded = "#{CMD} #{word} #{cmd}\n".cmd_fold(term_width)
+      text_arr << "  #{folded}"
     end
 
-    text_arr.<< "  #{CMD} #{word} --help"
+    text_arr << "  #{CMD} #{word} --help"
     text_arr.join("\n")
   end
 
@@ -124,15 +125,15 @@ class WavefrontCommandBase
                  global_option_text(width, term_width)
                end
 
-    text_arr.<< 'Options:'
-    _options.flatten.each { |o| text_arr.<< opt_row(o, width, term_width) }
+    text_arr << 'Options:'
+    _options.flatten.each { |o| text_arr << opt_row(o, width, term_width) }
     text_arr.join("\n")
   end
 
   def global_option_text(width, term_width)
     text_arr = ['Global options:']
-    global_options.each { |o| text_arr.<< opt_row(o, width, term_width) }
-    text_arr.<< ''
+    global_options.each { |o| text_arr << opt_row(o, width, term_width) }
+    text_arr << ''
   end
 
   # Formats an option string.
@@ -165,6 +166,6 @@ class WavefrontCommandBase
   # @return [String] a full options string which docopt understands
   #
   def docopt
-    commands + "\n\n" + options + "\n\n" + postscript
+    "#{commands}\n\n#{options}\n\n#{postscript}"
   end
 end

--- a/lib/wavefront-cli/commands/query.rb
+++ b/lib/wavefront-cli/commands/query.rb
@@ -45,7 +45,7 @@ class WavefrontCommandQuery < WavefrontCommandBase
   def postscript
     'The query command has an additional output format. Using ' \
     "'-f wavefront' produces output suitable for feeding back into a " \
-    "proxy. Other output formats are 'yaml', 'json', 'ruby', "\
+    "proxy. Other output formats are 'yaml', 'json', 'ruby', " \
     "and 'csv'. CSV format options are 'headers' (print column headers); " \
     "'tagkeys' (print tags as key=value rather than value); and 'quote' " \
     '(force quoting of every CSV element).'.cmd_fold(TW, 0)

--- a/lib/wavefront-cli/config.rb
+++ b/lib/wavefront-cli/config.rb
@@ -54,7 +54,7 @@ module WavefrontCli
 
     def do_show
       present?
-      puts IO.read(config_file)
+      puts File.read(config_file)
     end
 
     def do_about
@@ -97,7 +97,7 @@ module WavefrontCli
       prof_arr = ["[#{profile}]"]
 
       CONFIGURABLES.each do |c|
-        prof_arr.<< format('%<key>s=%<value>s',
+        prof_arr << format('%<key>s=%<value>s',
                            key: c[:key],
                            value: read_thing(c))
       end
@@ -138,8 +138,8 @@ module WavefrontCli
 
     def input_prompt(label, default)
       ret = format('  %<label>s', label: label)
-      ret.<< format(' [%<value>s]', value: default) unless default.nil?
-      ret + ':> '
+      ret << format(' [%<value>s]', value: default) unless default.nil?
+      "#{ret}:> "
     end
 
     # Read STDIN and strip the whitespace. The rescue is there to

--- a/lib/wavefront-cli/constants.rb
+++ b/lib/wavefront-cli/constants.rb
@@ -3,6 +3,7 @@
 require 'pathname'
 
 module WavefrontCli
+  #
   # Universal truths
   #
   module Constants
@@ -24,7 +25,7 @@ module WavefrontCli
 
     # Default configuration file
     #
-    DEFAULT_CONFIG = (Pathname.new(ENV['HOME']) + '.wavefront').freeze
+    DEFAULT_CONFIG = Pathname.new(Dir.home).join('.wavefront').freeze
 
     # Split regex for searches
     #

--- a/lib/wavefront-cli/controller.rb
+++ b/lib/wavefront-cli/controller.rb
@@ -7,8 +7,8 @@
 
 if defined?(DEVELOPMENT)
   dir = Pathname.new(__dir__).realpath.parent.parent.parent
-  $LOAD_PATH.<< dir + 'lib'
-  $LOAD_PATH.<< dir + 'wavefront-sdk' + 'lib'
+  $LOAD_PATH << dir.join('lib')
+  $LOAD_PATH << dir.join('wavefront-sdk', 'lib')
 end
 
 require 'pathname'
@@ -20,7 +20,7 @@ require_relative 'opt_handler'
 require_relative 'exception_handler'
 require_relative 'stdlib/string'
 
-CMD_DIR = Pathname.new(__dir__) + 'commands'
+CMD_DIR = Pathname.new(__dir__).join('commands')
 
 # Dynamically generate a CLI interface from files which describe
 # each subcomand.
@@ -65,13 +65,13 @@ class WavefrontCliController
          'Commands:']
 
     cmds.sort.each do |k, v|
-      s.<< format('  %-18<command>s %<desc>s',
+      s << format('  %-18<command>s %<desc>s',
                   command: k,
                   desc: v.description)
     end
 
-    s.<< ''
-    s.<< "Use '#{CMD} <command> --help' for further information."
+    s << ''
+    s << "Use '#{CMD} <command> --help' for further information."
     s.join("\n")
   end
   # rubocop:enable Metrics/MethodLength
@@ -124,7 +124,7 @@ class WavefrontCliController
 
   def load_cli_class(cmd, opts)
     require_relative File.join('.', cmds[cmd].sdk_file)
-    Object.const_get('WavefrontCli').const_get(cmds[cmd].sdk_class).new(opts)
+    Object.const_get(:WavefrontCli).const_get(cmds[cmd].sdk_class).new(opts)
   end
 
   def run_command(cli_class_obj)
@@ -146,7 +146,7 @@ class WavefrontCliController
   #
   def handle_missing_credentials(error)
     message = error.message.capitalize
-    message.<<('.') unless message.end_with?('.')
+    message << ('.') unless message.end_with?('.')
 
     puts "Credential error. #{message}"
 

--- a/lib/wavefront-cli/display/printer/long.rb
+++ b/lib/wavefront-cli/display/printer/long.rb
@@ -84,7 +84,7 @@ module WavefrontDisplayPrinter
       elsif data.is_a?(Array)
         append_array(data, aggr, depth, last_key)
       else
-        aggr.<< ['', preened_value(data), depth]
+        aggr << ['', preened_value(data), depth]
       end
     end
     # rubocop:enable Style/CaseLikeIf
@@ -99,16 +99,14 @@ module WavefrontDisplayPrinter
     # @return [Integer]
     #
     def longest_key_col(data)
-      data.map { |d| d[0].size + opts[:padding] + opts[:indent] * d[2] }.max
+      data.map { |d| d[0].size + opts[:padding] + (opts[:indent] * d[2]) }.max
     end
 
     # Turn the list made by #make_list into user output
     # @return [String]
     #
     def to_s
-      list.map do |item|
-        stringify_line(item)
-      end.join("\n")
+      list.map { |item| stringify_line(item) }.join("\n")
     end
 
     # @param item [Array] of the form [key, value, indent_level]
@@ -162,7 +160,7 @@ module WavefrontDisplayPrinter
         elsif v.is_a?(Array)
           aggr = append_array_values(k, v, aggr, depth)
         else
-          aggr.<< [k, smart_value(v), depth]
+          aggr << [k, smart_value(v), depth]
         end
       end
 
@@ -183,7 +181,7 @@ module WavefrontDisplayPrinter
 
         if opts[:separator] && element.is_a?(Hash) && i < data.size &&
            depth < opts[:sep_depth]
-          aggr.<< ['', :separator, depth]
+          aggr << ['', :separator, depth]
         end
       end
 
@@ -202,9 +200,9 @@ module WavefrontDisplayPrinter
     #
     def append_hash_values(key, values, aggr, depth)
       if values.empty? && opts[:none]
-        aggr.<< [key, '<none>', depth]
+        aggr << [key, '<none>', depth]
       else
-        aggr.<< [key, nil, depth]
+        aggr << [key, nil, depth]
         make_list(values, aggr, depth + 1)
       end
     end
@@ -218,13 +216,13 @@ module WavefrontDisplayPrinter
     #
     def append_array_values(key, values, aggr, depth)
       if values.empty? && opts[:none]
-        aggr.<< [key, '<none>', depth]
+        aggr << [key, '<none>', depth]
       elsif values.all?(String)
         values.sort!
-        aggr.<< [key, preened_value(values.shift), depth]
+        aggr << [key, preened_value(values.shift), depth]
         make_list(values, aggr, depth, key)
       else
-        aggr.<< [key, nil, depth]
+        aggr << [key, nil, depth]
         make_list(values, aggr, depth + 1, key)
       end
     end

--- a/lib/wavefront-cli/display/printer/sparkline.rb
+++ b/lib/wavefront-cli/display/printer/sparkline.rb
@@ -16,7 +16,7 @@ class WavefrontSparkline
   attr_reader :sparkline
 
   def initialize(series)
-    @sparkline = '>' + generate_sparkline(series) + '<'
+    @sparkline = ">#{generate_sparkline(series)}<"
   end
 
   # @return [String] the block corresponding to the given value in
@@ -38,8 +38,8 @@ class WavefrontSparkline
   def make_fit(vals)
     return vals if vals.size < SPARK_WIDTH
 
-    vals.<< vals.last if vals.size.odd?
-    ret = vals.each_slice(2).with_object([]) { |s, a| a.<< s.sum / 2 }
+    vals << vals.last if vals.size.odd?
+    ret = vals.each_slice(2).with_object([]) { |s, a| a << (s.sum / 2) }
     make_fit(ret)
   end
 

--- a/lib/wavefront-cli/display/query.rb
+++ b/lib/wavefront-cli/display/query.rb
@@ -86,7 +86,7 @@ module WavefrontDisplay
       if data.empty?
         puts 'No aliases defined.'
       else
-        data.each_key { |k| puts k.to_s[2..-1] }
+        data.each_key { |k| puts k.to_s[2..] }
       end
     end
 

--- a/lib/wavefront-cli/event.rb
+++ b/lib/wavefront-cli/event.rb
@@ -38,7 +38,7 @@ module WavefrontCli
     def do_show
       events = state.list
 
-      if events.size.zero?
+      if events.empty?
         puts 'No open events.'
       else
         events.sort.reverse_each { |e| puts e.basename }
@@ -94,7 +94,7 @@ module WavefrontCli
     end
 
     def window_start
-      parse_time((options[:start] || Time.now - 600), true)
+      parse_time((options[:start] || (Time.now - 600)), true)
     end
 
     def window_end

--- a/lib/wavefront-cli/helpers/load_file.rb
+++ b/lib/wavefront-cli/helpers/load_file.rb
@@ -40,11 +40,11 @@ module WavefrontCli
       private
 
       def load_json(file)
-        read_json(IO.read(file))
+        read_json(File.read(file))
       end
 
       def load_yaml(file)
-        read_yaml(IO.read(file))
+        read_yaml(File.read(file))
       end
 
       # Read STDIN and return a Ruby object, assuming that STDIN is

--- a/lib/wavefront-cli/maintenancewindow.rb
+++ b/lib/wavefront-cli/maintenancewindow.rb
@@ -27,7 +27,7 @@ module WavefrontCli
 
       [%i[CustomerTags atag], %i[HostTags htag],
        %i[HostNames host]].each do |key, opt|
-        k = ('relevant' + key.to_s).to_sym
+        k = "relevant#{key}".to_sym
         body[k] = options[opt] unless options[opt].empty?
       end
 

--- a/lib/wavefront-cli/output/csv/query.rb
+++ b/lib/wavefront-cli/output/csv/query.rb
@@ -32,7 +32,7 @@ module WavefrontCsvOutput
     def raw_output
       resp.each_with_object([]) do |point, a|
         point[:points].each do |p|
-          a.<< csv_format(options[:'<metric>'],
+          a << csv_format(options[:'<metric>'],
                           p[:value],
                           p[:timestamp],
                           options[:host],
@@ -48,7 +48,7 @@ module WavefrontCsvOutput
 
       resp[:timeseries].each_with_object([]) do |ts, a|
         ts[:data].each do |point|
-          a.<< csv_format(ts[:label],
+          a << csv_format(ts[:label],
                           point[1],
                           point[0],
                           ts[:host],

--- a/lib/wavefront-cli/output/hcl/dashboard.rb
+++ b/lib/wavefront-cli/output/hcl/dashboard.rb
@@ -32,19 +32,19 @@ module WavefrontHclOutput
     # @return [String] HCL list of vals
     #
     def listmaker(vals, method)
-      vals.each_with_object([]) { |v, a| a.<< send(method, v) }.to_hcl_list
+      vals.each_with_object([]) { |v, a| a << send(method, v) }.to_hcl_list
     end
 
     def vhandle_sections(vals)
       vals.each_with_object([]) do |section, a|
-        a.<< ("name = \"#{section[:name]}\"\n      row = " +
+        a << ("name = \"#{section[:name]}\"\n      row = " +
               handle_rows(section[:rows])).braced(4)
       end.to_hcl_list
     end
 
     def handle_rows(rows)
       rows.each_with_object([]) do |row, a|
-        a.<< ('chart = ' + handle_charts(row[:charts]).to_s).braced(8)
+        a << "chart = #{handle_charts(row[:charts])}".braced(8)
       end.to_hcl_list
     end
 
@@ -58,10 +58,10 @@ module WavefrontHclOutput
       lines = chart.each_with_object([]) do |(k, v), a|
         next unless fields.include?(k)
 
-        a.<< format('%<key>s = %<value>s', key: k, value: quote_value(v))
+        a << format('%<key>s = %<value>s', key: k, value: quote_value(v))
       end
 
-      lines.<< "source = #{handle_sources(chart[:sources])}"
+      lines << "source = #{handle_sources(chart[:sources])}"
       lines.to_hcl_obj(10)
     end
 
@@ -75,7 +75,7 @@ module WavefrontHclOutput
 
         k = 'queryBuilderEnabled' if k == 'querybuilderEnabled'
 
-        a.<< format('%<key>s = %<value>s',
+        a << format('%<key>s = %<value>s',
                     key: k.to_snake,
                     value: quote_value(v))
       end.to_hcl_obj(14)

--- a/lib/wavefront-cli/output/hcl/stdlib/array.rb
+++ b/lib/wavefront-cli/output/hcl/stdlib/array.rb
@@ -9,7 +9,7 @@ class Array
   # @return [String]
   #
   def to_hcl_list
-    '[' + join(',') + ']'
+    "[#{join(',')}]"
   end
 
   # Turn an array into a string which represents an HCL object

--- a/lib/wavefront-cli/output/wavefront/query.rb
+++ b/lib/wavefront-cli/output/wavefront/query.rb
@@ -20,11 +20,11 @@ module WavefrontWavefrontOutput
     def raw_output
       resp.each_with_object('') do |point, a|
         point[:points].each do |p|
-          a.<< wavefront_format(options[:'<metric>'],
-                                p[:value],
-                                p[:timestamp],
-                                options[:host],
-                                point[:tags]) + "\n"
+          a << "#{wavefront_format(options[:'<metric>'],
+                                   p[:value],
+                                   p[:timestamp],
+                                   options[:host],
+                                   point[:tags])}\n"
         end
       end
     end
@@ -34,7 +34,7 @@ module WavefrontWavefrontOutput
 
       resp[:timeseries].each_with_object([]) do |ts, a|
         ts[:data].each do |point|
-          a.<< wavefront_format(ts[:label],
+          a << wavefront_format(ts[:label],
                                 point[1],
                                 point[0],
                                 ts[:host],
@@ -46,7 +46,7 @@ module WavefrontWavefrontOutput
     def wavefront_format(path, value, timestamp, source, tags = nil)
       arr = [path, value, timestamp, format('source=%<source>s',
                                             source: source)]
-      arr.<< tags.to_wf_tag if tags && !tags.empty?
+      arr << tags.to_wf_tag if tags && !tags.empty?
       arr.join(' ')
     end
   end

--- a/lib/wavefront-cli/stdlib/string.rb
+++ b/lib/wavefront-cli/stdlib/string.rb
@@ -10,7 +10,7 @@ class String
   # @param indent [Integer] size of hanging indent, in chars
   #
   def cmd_fold(twidth = TW, indent = 10)
-    gsub(/(-\w) /, '\\1^').scan_line(twidth - 12).join("\n" + ' ' * indent)
+    gsub(/(-\w) /, '\\1^').scan_line(twidth - 12).join("\n#{' ' * indent}")
                           .restored
   end
 
@@ -58,7 +58,7 @@ class String
   #
   def value_fold(indent = 0, twidth = TW)
     max_line_length = twidth - indent - 4
-    scan_line(max_line_length).join("\n" + ' ' * indent)
+    scan_line(max_line_length).join("\n#{' ' * indent}")
   end
 
   # @param width [Integer] length of longest string (width of
@@ -94,7 +94,7 @@ class String
   #
   def to_snake
     gsub(/(.)([A-Z])/) do
-      Regexp.last_match[1] + '_' + Regexp.last_match[2].downcase
+      "#{Regexp.last_match[1]}_#{Regexp.last_match[2].downcase}"
     end
   end
 
@@ -102,7 +102,7 @@ class String
 
   def indent_folded_lines(chunks, twidth, indent, prefix)
     chunks.join(' ').scan_line(twidth - indent - 5).map do |line|
-      prefix + ' ' * indent + line
+      "#{prefix}#{' ' * indent}#{line}"
     end
   end
 end

--- a/lib/wavefront-cli/usage.rb
+++ b/lib/wavefront-cli/usage.rb
@@ -18,7 +18,7 @@ module WavefrontCli
     end
 
     def default_start
-      parse_time(Time.now - 60 * 60 * 24)
+      parse_time(Time.now - 86_400)
     end
   end
 end

--- a/lib/wavefront-cli/write.rb
+++ b/lib/wavefront-cli/write.rb
@@ -163,7 +163,7 @@ module WavefrontCli
     #
     def process_input_file(data)
       data.each_with_object([]) do |l, a|
-        a.<< process_line(l)
+        a << process_line(l)
       rescue WavefrontCli::Exception::UnparseableInput => e
         puts "Bad input. #{e.message}."
         next
@@ -422,7 +422,7 @@ module WavefrontCli
     #
     def valid_timestamp?(timestamp)
       (timestamp.is_a?(Integer) ||
-        timestamp.is_a?(String) && timestamp.match(/^\d+$/)) &&
+        (timestamp.is_a?(String) && timestamp.match(/^\d+$/))) &&
         timestamp.to_i > 946_684_800 &&
         timestamp.to_i < (Time.now.to_i + 31_557_600)
     end
@@ -432,7 +432,7 @@ module WavefrontCli
     end
 
     def load_data(file)
-      IO.read(file)
+      File.read(file)
     rescue StandardError
       raise WavefrontCli::Exception::FileNotFound
     end

--- a/spec/constants.rb
+++ b/spec/constants.rb
@@ -12,10 +12,9 @@ TW = 80
 
 ENDPOINT = 'metrics.wavefront.com'
 TOKEN = '0123456789-ABCDEF'
-RES_DIR = ROOT + 'spec' + 'wavefront-cli' + 'resources'
-CF = RES_DIR + 'wavefront.conf'
+RES_DIR = ROOT.join('spec', 'wavefront-cli', 'resources')
+CF = RES_DIR.join('wavefront.conf')
 CF_VAL =  IniFile.load(CF)
-JSON_POST_HEADERS = {
-  'Content-Type': 'application/json', Accept: 'application/json'
-}.freeze
+JSON_POST_HEADERS = { 'Content-Type': 'application/json',
+                      Accept: 'application/json' }.freeze
 TEE_ZERO = Time.now.freeze

--- a/spec/support/command_base.rb
+++ b/spec/support/command_base.rb
@@ -88,7 +88,7 @@ class EndToEndTest < MiniTest::Test
     end
   end
 
-  def have_config?
-    (Pathname.new(ENV['HOME']) + '.wavefront').exist?
+  def config?
+    Pathname.new(Dir.home).join('.wavefront').exist?
   end
 end

--- a/spec/support/minitest_assertions.rb
+++ b/spec/support/minitest_assertions.rb
@@ -220,7 +220,7 @@ module Minitest
     def mk_headers(token = nil, extra_headers = {})
       { Accept: /.*/,
         'Accept-Encoding': /.*/,
-        Authorization: 'Bearer ' + (token || '0123456789-ABCDEF'),
+        Authorization: "Bearer #{token || '0123456789-ABCDEF'}",
         'User-Agent': "wavefront-cli-#{WF_CLI_VERSION}" }.merge(extra_headers)
     end
 

--- a/spec/support/output_tester.rb
+++ b/spec/support/output_tester.rb
@@ -14,7 +14,7 @@ class OutputTester
   # @return [Object] canned raw responses used to test outputs
   #
   def load_input(file, only_items = true)
-    ret = JSON.parse(IO.read(RES_DIR + 'display' + file),
+    ret = JSON.parse(File.read(RES_DIR.join('display', file)),
                      symbolize_names: true)
     only_items ? ret[:items] : ret
   end
@@ -23,7 +23,7 @@ class OutputTester
   # @return [String]
   #
   def load_expected(file)
-    IO.read(RES_DIR + 'display' + file)
+    File.read(RES_DIR.join('display', file))
   end
 
   def in_and_out(input, expected, only_items = true)

--- a/spec/support/supported_commands.rb
+++ b/spec/support/supported_commands.rb
@@ -2,11 +2,13 @@
 
 require_relative '../constants'
 
+# Produces a list of wf's commands
+#
 class SupportedCommands
   attr_reader :cmd_dir
 
   def initialize
-    @cmd_dir = ROOT + 'lib' + 'wavefront-cli' + 'commands'
+    @cmd_dir = ROOT.join('lib', 'wavefront-cli', 'commands')
   end
 
   def all

--- a/spec/test_mixins/import.rb
+++ b/spec/test_mixins/import.rb
@@ -61,11 +61,11 @@ module WavefrontCliTest
     private
 
     def import_file
-      RES_DIR + 'imports' + "#{api_path}.json"
+      RES_DIR.join('imports', "#{api_path}.json")
     end
 
     def update_file
-      RES_DIR + 'updates' + "#{api_path}.json"
+      RES_DIR.join('updates', "#{api_path}.json")
     end
   end
 end

--- a/spec/test_mixins/search.rb
+++ b/spec/test_mixins/search.rb
@@ -18,17 +18,19 @@ module WavefrontCliTest
                          sort: { field: 'id', ascending: true })
       end
 
+      json_body = { limit: 10,
+                    offset: 0,
+                    query: [{ key: 'id',
+                              value: id,
+                              matchingMethod: 'EXACT',
+                              negated: false }],
+                    sort: { field: 'id', ascending: true } }.to_json
+
       assert_noop(
         "search id=#{id}",
         'uri: POST https://default.wavefront.com/api/v2/search/' \
         "#{search_api_path}",
-        'body: ' + { limit: 10,
-                     offset: 0,
-                     query: [{ key: 'id',
-                               value: id,
-                               matchingMethod: 'EXACT',
-                               negated: false }],
-                     sort: { field: 'id', ascending: true } }.to_json
+        "body: #{json_body}"
       )
       assert_abort_on_missing_creds("search id=#{id}")
       assert_usage('search')

--- a/spec/wavefront-cli/account_spec.rb
+++ b/spec/wavefront-cli/account_spec.rb
@@ -228,10 +228,12 @@ class AccountEndToEndTest < EndToEndTest
     cmd = "validate #{user_list.join(' ')}"
 
     quietly do
-      assert_cmd_posts(cmd,
-                       '/api/v2/account/validateAccounts',
-                       user_list.to_json,
-                       IO.read(RES_DIR + 'responses' + 'user-validate.json'))
+      assert_cmd_posts(
+        cmd,
+        '/api/v2/account/validateAccounts',
+        user_list.to_json,
+        File.read(RES_DIR.join('responses', 'user-validate.json'))
+      )
     end
 
     assert_noop(cmd,

--- a/spec/wavefront-cli/alert_spec.rb
+++ b/spec/wavefront-cli/alert_spec.rb
@@ -26,7 +26,7 @@ class AlertEndToEndTest < EndToEndTest
   # file.
   #
   def test_no_config_no_envvars
-    skip if have_config?
+    skip if config?
 
     blank_envvars
     wf = WavefrontCliController
@@ -67,10 +67,12 @@ class AlertEndToEndTest < EndToEndTest
                        id: id, v: nil, name: nil)
     end
 
+    json_body = { id: id, name: nil, v: nil }.to_json
+
     assert_noop("clone #{id}",
                 'uri: POST https://default.wavefront.com/api/v2/' \
                 "alert/#{id}/clone",
-                'body: ' + { id: id, name: nil, v: nil }.to_json)
+                "body: #{json_body}")
 
     assert_invalid_id("clone #{invalid_id}")
     assert_usage('clone')
@@ -84,10 +86,12 @@ class AlertEndToEndTest < EndToEndTest
                        id: id, v: 5, name: nil)
     end
 
+    json_body = { id: id, name: nil, v: 5 }.to_json
+
     assert_noop("clone #{id} --version 5",
                 'uri: POST https://default.wavefront.com/api/v2/' \
                 "alert/#{id}/clone",
-                'body: ' + { id: id, name: nil, v: 5 }.to_json)
+                "body: #{json_body}")
 
     assert_invalid_id("clone -v 10 #{invalid_id}")
     assert_usage('clone -v')
@@ -192,7 +196,7 @@ class AlertEndToEndTest < EndToEndTest
     assert_noop('snoozed',
                 'uri: POST https://default.wavefront.com/api/v2/' \
                 'search/alert',
-                'body: ' + state_search('snoozed').to_json)
+                "body: #{state_search('snoozed').to_json}")
 
     assert_abort_on_missing_creds('snoozed')
   end
@@ -212,7 +216,7 @@ class AlertEndToEndTest < EndToEndTest
     assert_noop('firing',
                 'uri: POST https://default.wavefront.com/api/v2/' \
                 'search/alert',
-                'body: ' + state_search('firing').to_json)
+                "body: #{state_search('firing').to_json}")
 
     assert_abort_on_missing_creds('firing')
   end
@@ -232,7 +236,7 @@ class AlertEndToEndTest < EndToEndTest
     assert_noop('currently firing',
                 'uri: POST https://default.wavefront.com/api/v2/' \
                 'search/alert',
-                'body: ' + state_search('firing').to_json)
+                "body: #{state_search('firing').to_json}")
 
     assert_abort_on_missing_creds('currently firing')
   end
@@ -252,7 +256,7 @@ class AlertEndToEndTest < EndToEndTest
     assert_noop('currently in_maintenance',
                 'uri: POST https://default.wavefront.com/api/v2/' \
                 'search/alert',
-                'body: ' + state_search('in_maintenance').to_json)
+                "body: #{state_search('in_maintenance').to_json}")
 
     assert_abort_on_missing_creds('currently in_maintenance')
   end

--- a/spec/wavefront-cli/commands/base_spec.rb
+++ b/spec/wavefront-cli/commands/base_spec.rb
@@ -68,7 +68,7 @@ class WavefrontCommmandBaseTest < MiniTest::Test
     assert wf.commands.start_with?("Usage:\n")
     assert wf.commands.match(/ --help$/)
 
-    wf.commands(600).split("\n")[1..-1].each do |c|
+    wf.commands(600).split("\n")[1..].each do |c|
       next if skip_cmd && c.match(skip_cmd)
 
       assert_match(/^  \w+/, c)
@@ -80,7 +80,7 @@ class WavefrontCommmandBaseTest < MiniTest::Test
     assert wf.options(600).start_with?("Global options:\n")
     assert_match(/\nOptions:/, wf.options)
 
-    wf.options(600).split("\n")[1..-1].each do |o|
+    wf.options(600).split("\n")[1..].each do |o|
       next if o == 'Global options:' || o == 'Options:' || o.empty?
 
       assert_instance_of(String, o)

--- a/spec/wavefront-cli/commands/config_spec.rb
+++ b/spec/wavefront-cli/commands/config_spec.rb
@@ -20,7 +20,7 @@ class WavefrontCommmandConfigTest < WavefrontCommmandBaseTest
     refute wf.options(600).start_with?("Global options:\n")
     assert_match(/Options:\n/, wf.options)
 
-    wf.options(600).split("\n")[1..-1].each do |o|
+    wf.options(600).split("\n")[1..].each do |o|
       next if o == 'Global options:' || o == 'Options:' || o.empty?
 
       assert_instance_of(String, o)
@@ -35,7 +35,7 @@ class WavefrontCommmandConfigTest < WavefrontCommmandBaseTest
     assert wf.commands.start_with?("Usage:\n")
     assert wf.commands.match(/ --help$/)
 
-    wf.commands(600).split("\n")[1..-1].each do |c|
+    wf.commands(600).split("\n")[1..].each do |c|
       next if skip_cmd && c.match(skip_cmd)
 
       assert_match(/^  \w+/, c)

--- a/spec/wavefront-cli/config_spec.rb
+++ b/spec/wavefront-cli/config_spec.rb
@@ -6,7 +6,7 @@ require 'minitest/autorun'
 require_relative '../constants'
 require_relative '../../lib/wavefront-cli/config'
 
-DEF_CF = Pathname.new(ENV['HOME']) + '.wavefront'
+DEF_CF = Pathname.new(Dir.home).join('.wavefront')
 CONF_TMP = Pathname.new('/tmp/outfile')
 
 # Test CLI configuration command
@@ -56,7 +56,7 @@ class WavefrontCliConfigTest < MiniTest::Test
     out, err = capture_io { assert_instance_of(IniFile, wf.base_config) }
     assert_empty(err)
 
-    if (Pathname.new(ENV['HOME']) + '.wavefront').exist?
+    if Pathname.new(Dir.home).join('.wavefront').exist?
       assert_empty(out)
     else
       assert_match(/Creating new configuration file at/, out)
@@ -196,7 +196,7 @@ class WavefrontCliConfigTest < MiniTest::Test
     assert_equal(
       "[other]\ntoken = abcdefab-0123-abcd-0123-abcdefabcdef\n" \
       "endpoint = other.wavefront.com\nproxy = otherwf.localnet\n\n",
-      IO.read(CONF_TMP)
+      File.read(CONF_TMP)
     )
 
     assert_raises(WavefrontCli::Exception::ProfileNotFound) do

--- a/spec/wavefront-cli/controller_spec.rb
+++ b/spec/wavefront-cli/controller_spec.rb
@@ -94,9 +94,11 @@ end
 # tested above.
 #
 # rubocop:disable Lint/MissingSuper
+# rubocop:disable Style/RedundantInitialize
 class Giblets < WavefrontCliController
   def initialize; end
 end
+# rubocop:enable Style/RedundantInitialize
 # rubocop:enable Lint/MissingSuper
 
 # Here's the subclass

--- a/spec/wavefront-cli/derivedmetric_spec.rb
+++ b/spec/wavefront-cli/derivedmetric_spec.rb
@@ -30,16 +30,18 @@ class DerivedMetricEndToEndTest < EndToEndTest
                        query: 'ts(series)')
     end
 
+    json_body = {
+      query: 'ts(series)',
+      name: 'mymetric',
+      minutes: 5,
+      includeObsoleteMetrics: false,
+      processRateMinutes: 1
+    }.to_json
+
     assert_noop('create mymetric ts(series)',
                 'uri: POST https://default.wavefront.com/api/v2/' \
                 'derivedmetric',
-                'body: ' + {
-                  query: 'ts(series)',
-                  name: 'mymetric',
-                  minutes: 5,
-                  includeObsoleteMetrics: false,
-                  processRateMinutes: 1
-                }.to_json)
+                "body: #{json_body}")
 
     assert_usage('create')
     assert_abort_on_missing_creds("create #{id} ts(series)")

--- a/spec/wavefront-cli/display/printer/long_spec.rb
+++ b/spec/wavefront-cli/display/printer/long_spec.rb
@@ -78,6 +78,7 @@ class TestWavefrontDisplayPrinterLong < MiniTest::Test
     assert_equal(22, pr.longest_key_col(input))
   end
 
+  # rubocop:disable Layout/LineContinuationLeadingSpace
   def test_to_s
     assert_equal("today\n" \
                  "  weather   sunny\n" \
@@ -92,24 +93,25 @@ class TestWavefrontDisplayPrinterLong < MiniTest::Test
                    key1: 'val1', key2: 'val2'
                  ).to_s)
   end
+  # rubocop:enable Layout/LineContinuationLeadingSpace
 
   def test_end_to_end
     input, expected = OutputTester.new.in_and_out('user-input.json',
                                                   'user-human-long')
     output = WavefrontDisplayPrinter::Long.new(input).to_s
-    assert_equal(expected, output + "\n")
+    assert_equal(expected, "#{output}\n")
 
     input, expected = OutputTester.new.in_and_out('user-input.json',
                                                   'user-human-long-no_sep')
     output = WavefrontDisplayPrinter::Long.new(input, nil, nil,
                                                separator: false).to_s
-    assert_equal(expected, output + "\n")
+    assert_equal(expected, "#{output}\n")
   end
 
   def test_end_to_end_fold
     input, expected = OutputTester.new.in_and_out('alert-input.json',
                                                   'alert-human-long')
     output = WavefrontDisplayPrinter::Long.new(input).to_s
-    assert_equal(expected, output + "\n")
+    assert_equal(expected, "#{output}\n")
   end
 end

--- a/spec/wavefront-cli/display/printer/terse_spec.rb
+++ b/spec/wavefront-cli/display/printer/terse_spec.rb
@@ -61,6 +61,6 @@ class WavefrontDisplayPrinterTerse < MiniTest::Test
     input, expected = OutputTester.new.in_and_out('alerts-input.json',
                                                   'alerts-human-terse')
     out = WavefrontDisplayPrinter::Terse.new(input, %i[id status name]).to_s
-    assert_equal(expected, out + "\n")
+    assert_equal(expected, "#{out}\n")
   end
 end

--- a/spec/wavefront-cli/event_spec.rb
+++ b/spec/wavefront-cli/event_spec.rb
@@ -99,7 +99,7 @@ class EventEndToEndTest < EndToEndTest
     assert state_file.exist?
     assert_equal(
       "{\"hosts\":[],\"description\":null,\"severity\":null,\"tags\":[]}\n",
-      IO.read(state_file)
+      File.read(state_file)
     )
 
     assert_abort_on_missing_creds("create #{event_name}")
@@ -131,7 +131,7 @@ class EventEndToEndTest < EndToEndTest
     assert state_file.exist?
     assert_equal('{"hosts":["host1","host2"],"description":"reason",' \
                  "\"severity\":null,\"tags\":[\"mytag\"]}\n",
-                 IO.read(state_file))
+                 File.read(state_file))
   end
 
   def test_create_instantaneous_with_start_time
@@ -173,20 +173,20 @@ class EventEndToEndTest < EndToEndTest
     @single_perm = true
 
     setup_test_state_dir
-    assert((state_dir + '1568133440530:ev3:0').exist?)
+    assert state_dir.join('1568133440530:ev3:0').exist?
 
     quietly do
       assert_cmd_posts('close', '/api/v2/event/1568133440530:ev3:0/close')
     end
 
-    refute((state_dir + '1568133440530:ev3:0').exist?)
-    assert((state_dir + '1568133440520:ev2:0').exist?)
+    refute state_dir.join('1568133440530:ev3:0').exist?
+    assert state_dir.join('1568133440520:ev2:0').exist?
 
     quietly do
       assert_cmd_posts('close', '/api/v2/event/1568133440520:ev2:0/close')
     end
 
-    refute((state_dir + '1568133440520:ev2:0').exist?)
+    refute state_dir.join('1568133440520:ev2:0').exist?
     @single_perm = false
   end
 

--- a/spec/wavefront-cli/event_store_spec.rb
+++ b/spec/wavefront-cli/event_store_spec.rb
@@ -53,7 +53,7 @@ class Test < MiniTest::Test
   end
 
   def test_create_dir_ok
-    dir = TEST_EVENT_STORE_DIR + 'testdir'
+    dir = TEST_EVENT_STORE_DIR.join('testdir')
     refute dir.exist?
     wf.create_dir(dir)
     assert dir.exist?
@@ -79,9 +79,9 @@ class Test < MiniTest::Test
   def test_pop_event
     setup_test_state_dir
 
-    assert (wf.dir + '1568133440530:ev3:0').exist?
+    assert wf.dir.join('1568133440530:ev3:0').exist?
     assert_equal('1568133440530:ev3:0', wf.pop_event!)
-    refute (wf.dir + '1568133440530:ev3:0').exist?
+    refute wf.dir.join('1568133440530:ev3:0').exist?
 
     empty_test_state_dir
   end
@@ -89,9 +89,9 @@ class Test < MiniTest::Test
   def test_pop_event_named
     setup_test_state_dir
 
-    assert (wf.dir + '1568133440515:ev1:1').exist?
+    assert wf.dir.join('1568133440515:ev1:1').exist?
     assert_equal('1568133440515:ev1:1', wf.pop_event!('ev1'))
-    refute (wf.dir + '1568133440515:ev1:1').exist?
+    refute wf.dir.join('1568133440515:ev1:1').exist?
 
     empty_test_state_dir
   end
@@ -99,9 +99,9 @@ class Test < MiniTest::Test
   def test_event_specific
     setup_test_state_dir
 
-    assert (wf.dir + '1568133440515:ev1:1').exist?
+    assert wf.dir.join('1568133440515:ev1:1').exist?
     assert_equal('1568133440515:ev1:1', wf.event('1568133440515:ev1:1'))
-    assert (wf.dir + '1568133440515:ev1:1').exist?
+    assert wf.dir.join('1568133440515:ev1:1').exist?
 
     empty_test_state_dir
   end

--- a/spec/wavefront-cli/externallink_spec.rb
+++ b/spec/wavefront-cli/externallink_spec.rb
@@ -24,11 +24,13 @@ class ExternalLinkEndToEndTest < EndToEndTest
                        description: 'mydescription')
     end
 
+    json_body = { name: 'myname',
+                  template: 'mytemplate',
+                  description: 'mydescription' }.to_json
+
     assert_noop('create myname mydescription mytemplate',
                 'uri: POST https://default.wavefront.com/api/v2/extlink',
-                'body: ' + { name: 'myname',
-                             template: 'mytemplate',
-                             description: 'mydescription' }.to_json)
+                "body: #{json_body}")
 
     assert_abort_on_missing_creds('create myname mydescription mytemplate')
     assert_usage('create myname mydescription')

--- a/spec/wavefront-cli/maintenancewindow_spec.rb
+++ b/spec/wavefront-cli/maintenancewindow_spec.rb
@@ -42,15 +42,17 @@ class MaintenanceWindowEndToEndTest < EndToEndTest
                        title: 'test_window')
     end
 
+    json_body = { title: 'test_window',
+                  startTimeInSeconds: 1_566_776_337,
+                  endTimeInSeconds: 1_566_776_399,
+                  reason: 'testing',
+                  relevantHostNames: %w[shark box] }.to_json
+
     assert_noop(
       'create --desc testing -H shark -s 1566776337 -H box ' \
       '-e 1566776399 test_window',
       'uri: POST https://default.wavefront.com/api/v2/maintenancewindow',
-      'body: ' + { title: 'test_window',
-                   startTimeInSeconds: 1_566_776_337,
-                   endTimeInSeconds: 1_566_776_399,
-                   reason: 'testing',
-                   relevantHostNames: %w[shark box] }.to_json
+      "body: #{json_body}"
     )
   end
 
@@ -172,16 +174,18 @@ class MaintenanceWindowEndToEndTest < EndToEndTest
       end
     end
 
+    json_body = { limit: 999,
+                  offset: 0,
+                  query: [{ key: 'runningState',
+                            value: 'ongoing',
+                            matchingMethod: 'EXACT' }],
+                  sort: { field: 'runningState',
+                          ascending: true } }.to_json
+
     assert_noop(
       'ongoing',
       'uri: POST https://default.wavefront.com/api/v2/search/maintenancewindow',
-      'body: ' + { limit: 999,
-                   offset: 0,
-                   query: [{ key: 'runningState',
-                             value: 'ongoing',
-                             matchingMethod: 'EXACT' }],
-                   sort: { field: 'runningState',
-                           ascending: true } }.to_json
+      "body: #{json_body}"
     )
 
     assert_empty(err)
@@ -198,16 +202,18 @@ class MaintenanceWindowEndToEndTest < EndToEndTest
       end
     end
 
+    json_body = { limit: 999,
+                  offset: 0,
+                  query: [{ key: 'runningState',
+                            value: 'pending',
+                            matchingMethod: 'EXACT' }],
+                  sort: { field: 'runningState',
+                          ascending: true } }.to_json
+
     assert_noop(
       'pending',
       'uri: POST https://default.wavefront.com/api/v2/search/maintenancewindow',
-      'body: ' + { limit: 999,
-                   offset: 0,
-                   query: [{ key: 'runningState',
-                             value: 'pending',
-                             matchingMethod: 'EXACT' }],
-                   sort: { field: 'runningState',
-                           ascending: true } }.to_json
+      "body: #{json_body}"
     )
 
     assert_empty(err)

--- a/spec/wavefront-cli/message_spec.rb
+++ b/spec/wavefront-cli/message_spec.rb
@@ -15,11 +15,11 @@ class MessageEndToEndTest < EndToEndTest
                       '/api/v2/message?limit=100&offset=0&unreadOnly=true')
     end
 
+    params = { offset: 0, limit: 100, unreadOnly: true }
+
     assert_noop('list',
                 'uri: GET https://default.wavefront.com/api/v2/message',
-                'params: ' + {
-                  offset: 0, limit: 100, unreadOnly: true
-                }.to_s)
+                "params: #{params}")
 
     assert_abort_on_missing_creds('list')
   end

--- a/spec/wavefront-cli/opt_handler_spec.rb
+++ b/spec/wavefront-cli/opt_handler_spec.rb
@@ -9,7 +9,7 @@ require_relative '../../lib/wavefront-cli/opt_handler'
 # Some of these tests will be skipped if you have a ~/.wavefront
 # config file. CI will never have that.
 #
-INTERFERING_FILE = Pathname.new(ENV['HOME']) + '.wavefront'
+INTERFERING_FILE = Pathname.new(Dir.home).join('.wavefront')
 
 # Test option handler class. End to end tests because the work is
 # always done in the constructor

--- a/spec/wavefront-cli/output/helpers.rb
+++ b/spec/wavefront-cli/output/helpers.rb
@@ -14,5 +14,5 @@ def load_raw_query_response
 end
 
 def load_file(file)
-  JSON.parse(IO.read(RES_DIR + file), symbolize_names: true)
+  JSON.parse(File.read(RES_DIR.join(file)), symbolize_names: true)
 end

--- a/spec/wavefront-cli/query_spec.rb
+++ b/spec/wavefront-cli/query_spec.rb
@@ -183,7 +183,7 @@ class QueryEndToEndTest < EndToEndTest
   end
 
   def canned_response
-    IO.read(RES_DIR + 'responses' + 'query.json')
+    File.read(RES_DIR.join('responses', 'query.json'))
   end
 end
 

--- a/spec/wavefront-cli/serviceaccount_spec.rb
+++ b/spec/wavefront-cli/serviceaccount_spec.rb
@@ -105,14 +105,16 @@ class ServiceAccountEndToEndTest < EndToEndTest
                        userGroups: [])
     end
 
+    json_body = { identifier: id,
+                  active: true,
+                  tokens: [],
+                  roles: [],
+                  userGroups: [] }.to_json
+
     assert_noop(
       "create #{id}",
       'uri: POST https://default.wavefront.com/api/v2/account/serviceaccount',
-      'body: ' + { identifier: id,
-                   active: true,
-                   tokens: [],
-                   roles: [],
-                   userGroups: [] }.to_json
+      "body: #{json_body}"
     )
 
     assert_abort_on_missing_creds("create #{id}")

--- a/spec/wavefront-cli/stdlib/string_spec.rb
+++ b/spec/wavefront-cli/stdlib/string_spec.rb
@@ -28,13 +28,14 @@ class StringTest < MiniTest::Test
 
     str = '-o, --option PARAMETER a rather pointless option with a ' \
           'needlessly wordy description string'
-    pad = "\n" + ' ' * 12
+    pad = "\n#{' ' * 12}"
     assert_equal("  -o, --option PARAMETER a#{pad}rather pointless" \
                  "#{pad}option with a#{pad}needlessly wordy#{pad}" \
                  "description#{pad}string",
                  str.opt_fold(30, 10))
   end
 
+  # rubocop:disable Layout/LineContinuationLeadingSpace
   def test_fold_options
     str = '-l, --longoption    a long option with a quite long ' \
           'description which needs folding'
@@ -48,6 +49,7 @@ class StringTest < MiniTest::Test
                  '      folding')
     assert_equal(str.opt_fold(100), "  #{str}")
   end
+  # rubocop:enable Layout/LineContinuationLeadingSpace
 
   def test_to_seconds
     assert_equal(14, '14s'.to_seconds)

--- a/spec/wavefront-cli/usage_spec.rb
+++ b/spec/wavefront-cli/usage_spec.rb
@@ -49,7 +49,7 @@ class UsageEndToEndTest < EndToEndTest
   end
 
   def response
-    IO.read(RES_DIR + 'responses' + 'usage-export-csv.json')
+    File.read(RES_DIR.join('responses', 'usage-export-csv.json'))
   end
 end
 

--- a/spec/wavefront-cli/write_class_spec.rb
+++ b/spec/wavefront-cli/write_class_spec.rb
@@ -159,7 +159,7 @@ class WavefrontCliWriteTest < MiniTest::Test
   def test_valid_timestamp?
     assert wf.valid_timestamp?(Time.now.to_i)
     refute wf.valid_timestamp?(Time.new(1999, 11, 30).to_i)
-    refute wf.valid_timestamp?(Time.now.to_i + 367 * 24 * 60 * 60)
+    refute wf.valid_timestamp?(Time.now.to_i + (367 * 24 * 60 * 60))
   end
 
   def test__sdk_class_and_default_port

--- a/wavefront-cli.gemspec
+++ b/wavefront-cli.gemspec
@@ -2,7 +2,6 @@
 
 require 'pathname'
 require 'date'
-
 require_relative 'lib/wavefront-cli/version'
 
 Gem::Specification.new do |gem|
@@ -20,22 +19,22 @@ Gem::Specification.new do |gem|
   gem.bindir        = 'bin'
   gem.files         = `git ls-files`.split("\n")
   gem.executables   = 'wf'
-  gem.test_files    = gem.files.grep(/^spec/)
   gem.require_paths = %w[lib]
 
-  gem.add_runtime_dependency 'docopt', '~> 0.6.0'
+  gem.add_runtime_dependency 'docopt', '~> 0.6'
   gem.add_runtime_dependency 'inifile', '~> 3.0'
-  gem.add_runtime_dependency 'wavefront-sdk', '~> 6.0'
+  gem.add_runtime_dependency 'wavefront-sdk', '~> 7.0'
 
-  gem.add_development_dependency 'minitest', '~> 5.14'
+  gem.add_development_dependency 'minitest', '~> 5.17'
   gem.add_development_dependency 'rake', '~> 13.0'
-  gem.add_development_dependency 'rubocop', '~> 1.11'
-  gem.add_development_dependency 'rubocop-minitest', '~> 0.10'
-  gem.add_development_dependency 'rubocop-performance', '~> 1.3'
-  gem.add_development_dependency 'rubocop-rake', '~> 0.5'
-  gem.add_development_dependency 'spy', '~> 1.0.0'
-  gem.add_development_dependency 'webmock', '~> 3.8'
-  gem.add_development_dependency 'yard', '~> 0.9.5'
+  gem.add_development_dependency 'rubocop', '~> 1.43'
+  gem.add_development_dependency 'rubocop-minitest', '~> 0.26'
+  gem.add_development_dependency 'rubocop-performance', '~> 1.15'
+  gem.add_development_dependency 'rubocop-rake', '~> 0.6'
+  gem.add_development_dependency 'spy', '~> 1.0'
+  gem.add_development_dependency 'webmock', '~> 3.18'
+  gem.add_development_dependency 'yard', '~> 0.9'
 
-  gem.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+  gem.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
+  gem.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Bring all dependencies up-to-date, and apply new Rubocop rules. Drop support for EOLed Rubies.